### PR TITLE
Fixed minimap, classcolors, PocketBar status and standard UI scale

### DIFF
--- a/RetailUI/Core.lua
+++ b/RetailUI/Core.lua
@@ -16,7 +16,12 @@ function RUI:OnInitialize()
 	AceConfig:RegisterOptionsTable("RUI Commands", RUI.optionsSlash, "rui")
 end
 
-function RUI:OnEnable() end
+function RUI:OnEnable()
+    if GetCVar("useUiScale") == "0" then
+        SetCVar("useUiScale", 1)
+        SetCVar("uiScale", 0.75)
+    end
+end
 
 function RUI:OnDisable() end
 
@@ -126,3 +131,23 @@ function CheckSettingsExists(self, widgets)
 	end
 	self:UpdateWidgets()
 end
+
+local function MoveChatOnFirstLoad()
+    local chat = ChatFrame1
+    if not chat then return end
+
+    if chat:IsUserPlaced() then return end
+
+    chat:ClearAllPoints()
+    chat:SetPoint("BOTTOMLEFT", UIParent, "BOTTOMLEFT", 32, 32)
+    chat:SetWidth(chat:GetWidth() - 40)
+    chat:SetMovable(true)
+    chat:SetUserPlaced(true)
+end
+
+local f = CreateFrame("Frame")
+f:RegisterEvent("PLAYER_ENTERING_WORLD")
+f:SetScript("OnEvent", function(self, event)
+    MoveChatOnFirstLoad()
+    self:UnregisterEvent("PLAYER_ENTERING_WORLD")
+end)

--- a/RetailUI/Core.lua
+++ b/RetailUI/Core.lua
@@ -6,6 +6,10 @@
 local RUI = LibStub('AceAddon-3.0'):NewAddon('RetailUI', 'AceConsole-3.0')
 local AceConfig = LibStub("AceConfig-3.0")
 local AceDB = LibStub("AceDB-3.0")
+RetailUIDB = RetailUIDB or {}
+if RetailUIDB.bagsExpanded == nil then
+    RetailUIDB.bagsExpanded = false -- Standard: sichtbar
+end
 
 RUI.InterfaceVersion = select(4, GetBuildInfo())
 RUI.Wrath = (RUI.InterfaceVersion >= 30300)

--- a/RetailUI/Modules/ActionBar.lua
+++ b/RetailUI/Modules/ActionBar.lua
@@ -650,7 +650,24 @@ local function ReplaceBlizzardBagsBarFrame(frameBar)
     toggleButton:SetPoint("LEFT", CharacterBag0Slot, "RIGHT", frameBar.gap, 1)
     toggleButton:SetSize(9, 17)
     toggleButton:SetHitRectInsets(0, 0, 0, 0)
+    local normalTexture = toggleButton:GetNormalTexture() or toggleButton:CreateTexture(nil, "BORDER")
+    normalTexture:SetAllPoints(toggleButton)
+    toggleButton:SetNormalTexture(normalTexture)
 
+    local highlightTexture = toggleButton:GetHighlightTexture() or toggleButton:CreateTexture(nil, "HIGHLIGHT")
+    highlightTexture:SetAllPoints(toggleButton)
+    toggleButton:SetHighlightTexture(highlightTexture)
+
+    if toggleButton.toggle then
+        SetAtlasTexture(normalTexture, 'CollapseButton-Left')
+        SetAtlasTexture(highlightTexture, 'CollapseButton-Left')
+        for _, button in pairs(bagSlotButtons) do button:Hide() end
+    else
+        SetAtlasTexture(normalTexture, 'CollapseButton-Right')
+        SetAtlasTexture(highlightTexture, 'CollapseButton-Right')
+        for _, button in pairs(bagSlotButtons) do button:Show() end
+    end
+    
     local normalTexture = toggleButton:GetNormalTexture() or toggleButton:CreateTexture(nil, "BORDER")
     normalTexture:SetAllPoints(toggleButton)
     SetAtlasTexture(normalTexture, 'CollapseButton-Left')
@@ -664,29 +681,25 @@ local function ReplaceBlizzardBagsBarFrame(frameBar)
     toggleButton:SetHighlightTexture(highlightTexture)
 
     toggleButton:SetScript("OnClick", function(self)
+        self.toggle = not self.toggle
+        RetailUIDB.bagsExpanded = not self.toggle
+
+        local normalTexture = self:GetNormalTexture()
+        local highlightTexture = self:GetHighlightTexture()
+
         if self.toggle then
-            local normalTexture = self:GetNormalTexture()
             SetAtlasTexture(normalTexture, 'CollapseButton-Left')
-
-            local highlightTexture = toggleButton:GetHighlightTexture()
             SetAtlasTexture(highlightTexture, 'CollapseButton-Left')
-
             for _, button in pairs(bagSlotButtons) do
                 button:Hide()
             end
         else
-            local normalTexture = self:GetNormalTexture()
             SetAtlasTexture(normalTexture, 'CollapseButton-Right')
-
-            local highlightTexture = toggleButton:GetHighlightTexture()
             SetAtlasTexture(highlightTexture, 'CollapseButton-Right')
-
-            for _, button in pairs(bagSlotButtons) do
+                for _, button in pairs(bagSlotButtons) do
                 button:Show()
             end
         end
-
-        self.toggle = not self.toggle
     end)
 
     local backpackButton = MainMenuBarBackpackButton

--- a/RetailUI/Modules/ActionBar.lua
+++ b/RetailUI/Modules/ActionBar.lua
@@ -646,39 +646,30 @@ local function ReplaceBlizzardBagsBarFrame(frameBar)
 
     frameBar.toggleButton = frameBar.toggleButton or CreateFrame('Button', nil, UIParent)
     local toggleButton = frameBar.toggleButton
-    toggleButton.toggle = false
     toggleButton:SetPoint("LEFT", CharacterBag0Slot, "RIGHT", frameBar.gap, 1)
     toggleButton:SetSize(9, 17)
     toggleButton:SetHitRectInsets(0, 0, 0, 0)
+
     local normalTexture = toggleButton:GetNormalTexture() or toggleButton:CreateTexture(nil, "BORDER")
     normalTexture:SetAllPoints(toggleButton)
-    toggleButton:SetNormalTexture(normalTexture)
 
     local highlightTexture = toggleButton:GetHighlightTexture() or toggleButton:CreateTexture(nil, "HIGHLIGHT")
     highlightTexture:SetAllPoints(toggleButton)
+
+    toggleButton:SetNormalTexture(normalTexture)
     toggleButton:SetHighlightTexture(highlightTexture)
 
-    if toggleButton.toggle then
-        SetAtlasTexture(normalTexture, 'CollapseButton-Left')
-        SetAtlasTexture(highlightTexture, 'CollapseButton-Left')
-        for _, button in pairs(bagSlotButtons) do button:Hide() end
-    else
+    if RetailUIDB and RetailUIDB.bagsExpanded then
+        toggleButton.toggle = false  -- Leiste ist offen
         SetAtlasTexture(normalTexture, 'CollapseButton-Right')
         SetAtlasTexture(highlightTexture, 'CollapseButton-Right')
         for _, button in pairs(bagSlotButtons) do button:Show() end
+    else
+        toggleButton.toggle = true  -- Leiste ist eingeklappt
+        SetAtlasTexture(normalTexture, 'CollapseButton-Left')
+        SetAtlasTexture(highlightTexture, 'CollapseButton-Left')
+        for _, button in pairs(bagSlotButtons) do button:Hide() end
     end
-    
-    local normalTexture = toggleButton:GetNormalTexture() or toggleButton:CreateTexture(nil, "BORDER")
-    normalTexture:SetAllPoints(toggleButton)
-    SetAtlasTexture(normalTexture, 'CollapseButton-Left')
-
-    toggleButton:SetNormalTexture(normalTexture)
-
-    local highlightTexture = toggleButton:GetHighlightTexture() or toggleButton:CreateTexture(nil, "HIGHLIGHT")
-    highlightTexture:SetAllPoints(toggleButton)
-    SetAtlasTexture(highlightTexture, 'CollapseButton-Left')
-
-    toggleButton:SetHighlightTexture(highlightTexture)
 
     toggleButton:SetScript("OnClick", function(self)
         self.toggle = not self.toggle
@@ -1078,6 +1069,13 @@ function Module:OnEnable()
 
     -- Bags
     self.bagsBar = CreateActionFrameBar(nil, 5, 50, 2, false, 'BagsBar')
+
+    -- Keyring
+    self:SecureHook("ToggleBackpack", function()
+        if not IsBagOpen(-2) then
+            KeyRingButton:SetChecked(false)
+        end
+    end)
 end
 
 function Module:OnDisable()

--- a/RetailUI/Modules/Minimap.lua
+++ b/RetailUI/Modules/Minimap.lua
@@ -43,6 +43,17 @@ local function ReplaceBlizzardFrame(frame)
     minimapZoneButton:ClearAllPoints()
     minimapZoneButton:SetPoint("LEFT", minimapBorderTop, "LEFT", 7, 1)
     minimapZoneButton:SetWidth(108)
+    
+    minimapZoneButton:EnableMouse(true)
+	minimapZoneButton:SetScript("OnMouseUp", function(self, button)
+    if button == "LeftButton" then
+		if WorldMapFrame:IsShown() then
+		    HideUIPanel(WorldMapFrame)
+		 else
+			ShowUIPanel(WorldMapFrame)
+		 end
+	end
+end)
 
     local minimapZoneText = MinimapZoneText
     minimapZoneText:SetAllPoints(minimapZoneButton)
@@ -209,8 +220,15 @@ local function CreateMinimapBorderFrame(width, height)
 end
 
 local function RemoveBlizzardFrames()
+    if MiniMapWorldMapButton then
+        MiniMapWorldMapButton:Hide()
+        MiniMapWorldMapButton:UnregisterAllEvents()
+        MiniMapWorldMapButton:SetScript("OnClick", nil)
+        MiniMapWorldMapButton:SetScript("OnEnter", nil)
+        MiniMapWorldMapButton:SetScript("OnLeave", nil)
+    end
+    
     local blizzFrames = {
-        MiniMapWorldMapButton,
         MiniMapTrackingIcon,
         MiniMapTrackingIconOverlay,
         MiniMapMailBorder,

--- a/RetailUI/Modules/UnitFrame.lua
+++ b/RetailUI/Modules/UnitFrame.lua
@@ -1053,6 +1053,33 @@ function Module:PLAYER_ENTERING_WORLD()
     }
 
     CheckSettingsExists(Module, widgets)
+
+    for i = 1, 4 do
+        local frame = _G["PartyMemberFrame" .. i]
+        if frame and frame.healthbar then
+            self:HookScript(frame.healthbar, "OnValueChanged", function(self)
+                local unit = frame.unit
+                if UnitIsPlayer(unit) and not UnitIsUnit(unit, "player") then
+                    local _, class = UnitClass(unit)
+                    local color = RAID_CLASS_COLORS[class]
+                    if color then
+                        self:SetStatusBarColor(color.r, color.g, color.b)
+                    end
+                end
+            end)
+
+            self:SecureHook(frame.healthbar, "SetStatusBarColor", function(bar, r, g, b)
+                local unit = frame.unit
+                if UnitIsPlayer(unit) and not UnitIsUnit(unit, "player") then
+                    local _, class = UnitClass(unit)
+                    local color = RAID_CLASS_COLORS[class]
+                    if color and (r ~= color.r or g ~= color.g or b ~= color.b) then
+                        bar:SetStatusBarColor(color.r, color.g, color.b)
+                    end
+                end
+            end)
+        end
+    end
 end
 
 function Module:LoadDefaultSettings()

--- a/RetailUI/Modules/UnitFrame.lua
+++ b/RetailUI/Modules/UnitFrame.lua
@@ -692,30 +692,21 @@ local function FocusFrame_SetSmallSize(smallSize, onChange)
     ReplaceBlizzardTargetFrame(Module.focusFrame, FocusFrame)
 end
 
-local healthBarClassColors = {
-    ["Death Knight"] = { r = 0.77, g = 0.12, b = 0.23 },
-    ["Druid"] = { r = 1, g = 0.49, b = 0.04 },
-    ["Hunter"] = { r = 0.67, g = 0.83, b = 0.45 },
-    ["Mage"] = { r = 0.25, g = 0.78, b = 0.92 },
-    ["Paladin"] = { r = 0.96, g = 0.55, b = 0.73 },
-    ["Priest"] = { r = 1, g = 1, b = 1 },
-    ["Rogue"] = { r = 1, g = 0.96, b = 0.41 },
-    ["Shaman"] = { r = 0, g = 0.44, b = 0.87 },
-    ["Warlock"] = { r = 0.53, g = 0.53, b = 0.93 },
-    ["Warrior"] = { r = 0.78, g = 0.61, b = 0.43 },
-}
-
-local function setHealthBarColor(statusBar)
-    if statusBar.unit == "target" then
-        local class = UnitClass("target")
-        if healthBarClassColors[class] then
-            statusBar:SetStatusBarColor(healthBarClassColors[class].r, healthBarClassColors[class].g, healthBarClassColors[class].b)
-        else
-            statusBar:SetStatusBarColor(0.48, 0.86, 0.15) -- if it's not a class put green color
-        end
-    else
-        statusBar:SetStatusBarColor(0.48, 0.86, 0.15)
+local function setHealthBarColor(statusBar, unit)
+    if not unit or not UnitExists(unit) then
+        return
     end
+
+    if UnitIsPlayer(unit) and not UnitIsUnit(unit, "player") then
+        local _, class = UnitClass(unit)
+        local color = RAID_CLASS_COLORS[class]
+
+        if color then
+            statusBar:SetStatusBarColor(color.r, color.g, color.b)
+            return
+        end
+    end
+    statusBar:SetStatusBarColor(0.48, 0.86, 0.15)
 end
 
 local function UnitFrameHealthBar_Update(statusBar, unit)
@@ -732,7 +723,7 @@ local function UnitFrameHealthBar_Update(statusBar, unit)
             end
         else
             if not statusBar.lockColor then
-                setHealthBarColor(statusBar)
+                setHealthBarColor(statusBar, unit)
             end
         end
     end


### PR DESCRIPTION
WorldMapButton
- dissabled WorldMapButton completely instead of just hide it
- added map toggle via click on the zonename above the minimap
solves: #15

ClassColorDisplay
- removed custom classtable
- added raidcolors
- fixed classcolor in targetframe, groupframe, focusframe
partially solves: #6
- Fixed party class colors resetting back to green

PocketBar
- the status of the pocket bar (whether it is open or closed) is now saved and reloaded when logging in
- Fix arrow position on load on expanded bagbar
- Fix highlight bug of keyring on close bags with backpack close

UI scale
- on first logon the UI scales automaticaly to 75% to fit all UI elements correctly
- on first logon the chatwindow position changes to the left lower corner and slightly shortened
possibly solves #7